### PR TITLE
Updating prometheus_client to 0.5.0

### DIFF
--- a/django_prometheus/__init__.py
+++ b/django_prometheus/__init__.py
@@ -1,10 +1,10 @@
 import os
-from prometheus_client import core
+from prometheus_client import values
 
 
 # Override pid function if we have a reusable gunicorn worker ID
 if os.environ.get('prometheus_multiproc_dir', None):  # noqa
-    core._ValueClass = core._MultiProcessValue(
+    values.ValueClass = values.MultiProcessValue(
         _pidFunc=lambda: os.environ.get('APP_WORKER_ID', 1000),
     )
 

--- a/django_prometheus/celery.py
+++ b/django_prometheus/celery.py
@@ -12,7 +12,7 @@ from celery.signals import (
     worker_process_shutdown,
     celeryd_init,
 )
-from prometheus_client import core, multiprocess, Counter, Histogram
+from prometheus_client import values, multiprocess, Counter, Histogram
 
 
 WORKER_ID_OFFSET = 1001  # 1000 is Celery main process
@@ -83,7 +83,7 @@ def on_task_retry(sender=None, **kwargs):
 @worker_process_init.connect
 def on_worker_process_init(*args, **kwargs):
     """Make use of stable worker IDs to name the dbfiles."""
-    core._ValueClass = core._MultiProcessValue(
+    values.ValueClass = values.MultiProcessValue(
         _pidFunc=lambda: current_process().index + WORKER_ID_OFFSET,
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.8
 django-redis>=4.8
 pep8>=1.6.2
-prometheus-client==0.4.0
+prometheus-client==0.5.0
 pip-prometheus>=1.1.0
 mock>=1.0.1
 mysqlclient

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ See https://github.com/prezi/django-exporter for usage instructions.
 
 setup(
     name="django-exporter",
-    version="2.0.3",
+    version="2.1.0",
     author="David Guerrero",
     author_email="david.guerrero@prezi.com",
     description="Export Django metrics for Prometheus.",
@@ -22,7 +22,7 @@ setup(
     test_suite="django_prometheus.tests",
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        "prometheus_client==0.4.0",
+        "prometheus_client==0.5.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Let's use the latest version of `prometheus_client`. There was some internal refactoring, hopefully the monkey patching for reusable worker IDs should still work.