### PR TITLE
Django 1.3 middleware metrics compatibility

### DIFF
--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -8,6 +8,9 @@ if django.VERSION >= (1, 10, 0):
 else:
     MiddlewareMixin = object
 
+if django.VERSION < (1, 5, 0):
+    from django.core.urlresolvers import resolve
+
 
 ACCEPTABLE_HTTP_METHODS = (
     'connect',
@@ -74,6 +77,11 @@ def request_view_name(request):
         if request.resolver_match is not None:
             if request.resolver_match.view_name is not None:
                 view_name = request.resolver_match.view_name
+    elif django.VERSION < (1, 5, 0) and hasattr(request, 'path'):
+        try:
+            view_name = resolve(request.path).url_name
+        except:  # No view match
+            pass
     return view_name
 
 

--- a/django_prometheus/urls.py
+++ b/django_prometheus/urls.py
@@ -1,5 +1,12 @@
-from django.conf.urls import url
+import django
+
+if django.VERSION < (1, 4, 0):
+    from django.conf.urls.defaults import url
+else:
+    from django.conf.urls import url
+
 from django_prometheus import exports
+
 
 urlpatterns = [
     url(r'^metrics$', exports.ExportToDjangoView,

--- a/django_prometheus/urls.py
+++ b/django_prometheus/urls.py
@@ -1,11 +1,10 @@
 import django
+from django_prometheus import exports
 
 if django.VERSION < (1, 4, 0):
     from django.conf.urls.defaults import url
 else:
     from django.conf.urls import url
-
-from django_prometheus import exports
 
 
 urlpatterns = [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ See https://github.com/prezi/django-exporter for usage instructions.
 
 setup(
     name="django-exporter",
-    version="2.1.1",
+    version="2.1.2",
     author="David Guerrero",
     author_email="david.guerrero@prezi.com",
     description="Export Django metrics for Prometheus.",


### PR DESCRIPTION
This will enable middleware collected metrics for Django 1.3. It would still work without this but without the view name resolution.