### PR TITLE
Making the celery task_name extraction a bit more resilient to missing data

### DIFF
--- a/django_prometheus/celery.py
+++ b/django_prometheus/celery.py
@@ -45,9 +45,9 @@ def on_after_task_publish(sender=None, headers=None, body=None, **kwargs):
     """Dispatched when a task has been sent to the broker.
     Note that this is executed in the process that sent the task.
     """
-    if 'task' in headers:
+    try:
         task_name = headers['task']
-    else:
+    except:  # headers['task'] is not always available
         task_name = 'UNKNOWN'
     tasks_published.labels(task=task_name).inc()
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ See https://github.com/prezi/django-exporter for usage instructions.
 
 setup(
     name="django-exporter",
-    version="2.1.2",
+    version="2.1.3",
     author="David Guerrero",
     author_email="david.guerrero@prezi.com",
     description="Export Django metrics for Prometheus.",


### PR DESCRIPTION
It's better to say the task_name is unknown than to crash the app.