### PR TITLE
add more buckets for view duration

### DIFF
--- a/django_prometheus/middleware.py
+++ b/django_prometheus/middleware.py
@@ -39,6 +39,10 @@ http_view_duration = Histogram(
     'django_view_duration_seconds',
     'Histogram of view processing duration.',
     ['handler'],
+    buckets=(
+        .005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0,
+        2.5, 5.0, 7.5, 10.0, 15.0, 30.0, 60.0, 120.0, 300.0
+    ),
 )
 http_template_responses = Counter(
     'django_http_template_responses',


### PR DESCRIPTION
Because of the 10s biggest bucket, if we had very slow (multiple minutes long) responses we
still saw 10s latency. 
This additional buckets improve on the resolution of the slow requests but also makes the calculations of percentiles slower
(more buckets to count with)

New buckets added that are not in the defaults: `15.0` `30.0` `60.0` `120.0` `300.0`