### PR TITLE
Add py37 and py38 environments for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+  - "3.8"
+  - "3.7"
   - "3.6"
   - "2.7"
 env:


### PR DESCRIPTION
Currently Python 3.7 and 3.8 are not included in the list of python versions. This PR fixes that "issues".